### PR TITLE
add people to about page; speculative image/video transition fix

### DIFF
--- a/studio/schemas/about.js
+++ b/studio/schemas/about.js
@@ -24,6 +24,24 @@ export default {
       title: 'Text',
       type: 'blockContent',
     },
+    {
+      name: 'locations',
+      title: 'Locations',
+      type: 'blockContent',
+    },
+    {
+      name: 'people',
+      title: 'People',
+      type: 'array',
+      of: [
+        { 
+          type: 'reference',
+          to: [
+            { type: 'people' },
+          ],
+        }
+      ],
+    },
   ],
   preview: {
     select: {

--- a/studio/schemas/person.js
+++ b/studio/schemas/person.js
@@ -1,8 +1,8 @@
 import UserIcon from 'part:@sanity/base/user-icon'
 
 export default {
-  name: 'person',
-  title: 'Person',
+  name: 'people',
+  title: 'People',
   type: 'document',
   icon: UserIcon,
   fields: [
@@ -11,6 +11,11 @@ export default {
       title: 'Name',
       type: 'string',
       description: 'Please use "Firstname Lastname" format',
+    },
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
     },
     {
       name: 'slug',
@@ -28,6 +33,11 @@ export default {
       options: {
         hotspot: true,
       },
+    },
+    {
+      name: 'text',
+      title: 'Text',
+      type: 'blockContent',
     },
   ],
   preview: {

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -13,6 +13,7 @@ import lensesPayloadTable from './lensesPayloadTable'
 import project from './project'
 import home from './home'
 import about from './about'
+import person from './person'
 import service from './service'
 
 // Then we give our schema to the builder and provide the result to Sanity
@@ -28,6 +29,7 @@ export default createSchema({
     home,
     about,
     service,
+    person,
     // When added to this list, object types can be used as
     // { type: 'typename' } in other document schemas
     blockContent,

--- a/web/components/layout.js
+++ b/web/components/layout.js
@@ -86,12 +86,8 @@ const Layout = ({
     setLoadVideo(true);
     setTimeout(() => {
       setSiteLoaded(true);
-    }, 500);
+    }, 300);
   }, []);
-
-  const onVideoStart = () => {
-    heroRef.current.style.background = "";
-  };
 
   return (
     <div
@@ -130,7 +126,6 @@ const Layout = ({
               title="Ravens Film Works"
               url={heroVideoUrl}
               width={`100%`}
-              onStart={onVideoStart}
             />
           </div>
         )}

--- a/web/pages/about.js
+++ b/web/pages/about.js
@@ -4,6 +4,7 @@ import urlForSanitySource from "../lib/urlForSanitySource";
 import groq from "groq";
 import Link from "next/link";
 import BlockContent from "@sanity/block-content-to-react";
+import Image from "next/image";
 
 const heroContent = () => {
   return (
@@ -17,13 +18,13 @@ const heroContent = () => {
 
 const About = (props) => {
   const { about = {} } = props;
+  console.log(about)
   
   return (
     <Layout 
       title="About | RAVENS"
       heroContent={heroContent()}
       heroImage={urlForSanitySource(about.poster).url()}
-      // heroImage="/images/about-bg-2.jpg"
     >
       <div className="container mx-auto text-center">
         <div className="max-w-5xl mx-auto mt-16">
@@ -31,12 +32,38 @@ const About = (props) => {
             <BlockContent blocks={about.text} />
           </section>
 
-          <Link href="/contact">
-            <a className="hidden lg:inline-block rounded-full font-bold uppercase tracking-wider border border-white py-2 px-8 hover:bg-gold hover:text-black transition-all">
-              Get in Touch
-            </a>
-          </Link>
-          <hr className="border-t-2 w-full lg:w-96 mx-auto border-gold my-16" />
+          <section className="text-center max-w-5xl mb-20 mx-8 lg:mx-auto">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
+            {about?.people?.map((person, index) => {
+              return (
+                <article key={person._id}>
+                  <header>
+                    <Image
+                      src={urlForSanitySource(person.image).url()}
+                      layout="intrinsic"
+                      width="300"
+                      height="300"
+                    />
+                    <p className="uppercase text-gold tracking-wider font-bold mb-2">
+                      {person.name}
+                      <br/>
+                      {person.title}
+                    </p>
+                    <BlockContent blocks={person.text} />
+                  </header>
+                </article>
+              );
+            })}          
+            </div>
+          </section> 
+          
+          <hr className="border-t-2 w-full  mx-auto border-gold my-16" />
+          
+          <section className="md:px-32 mb-20 user-text">
+            <BlockContent blocks={about.locations} />
+          </section>
+          
+          <hr className="border-t-2 w-full  mx-auto border-gold my-16" />
         </div>
       </div>
     </Layout>
@@ -47,7 +74,14 @@ export async function getStaticProps() {
   return {
     props: {
       about: await getClient().fetch(groq`
-        *[_type == "about"][0]
+        *[_type == "about"][0]{
+          title,
+          poster,
+          text,
+          locations,
+          title,
+          people[]->
+        }
       `),
     },
   };


### PR DESCRIPTION
1. add people to about schema utilizing existing person.js schema
2. add people to about page
3. add locations field to about page to break up text and locations
4. Speculative fix for image video transition jumpiness.